### PR TITLE
RSDT  test correction

### DIFF
--- a/tests/unit/grid/test_grid.cpp
+++ b/tests/unit/grid/test_grid.cpp
@@ -83,22 +83,14 @@ BOOST_AUTO_TEST_CASE(maxLevel_agrees_with_Dune)
     BOOST_CHECK_EQUAL(bemppGrid->maxLevel(), duneGrid->maxLevel());
 }
 
-// The test below fails because the numBoundarySegments method is not
-// implemented in FoamGrid yet.
-
-#if BOOST_VERSION >= 103500
-BOOST_AUTO_TEST_CASE_EXPECTED_FAILURES(boundarySegmentCount_agrees_with_Dune, 1)
-#else
-// See http://lists.boost.org/boost-users/2007/09/31144.php
-#   ifdef _MSC_VER
-#       pragma message("WARNING: Your version of Boost.Test does not register expected test failures correctly. Update to Boost 1.35 or newer.")
-#   else // perhaps GCC
-#       warning Your version of Boost.Test does not register expected test failures correctly. Update to Boost 1.35 or newer.
-#   endif
-#endif
 BOOST_AUTO_TEST_CASE(boundarySegmentCount_agrees_with_Dune)
 {
-    BOOST_CHECK_EQUAL(bemppGrid->boundarySegmentCount(), duneGrid->numBoundarySegments());
+  // The test below fails because the numBoundarySegments method is not
+  // implemented in FoamGrid yet.
+  BOOST_CHECK_THROW(duneGrid->numBoundarySegments(), std::exception);
+  // Just checking it goes through the motion without obvious errors, since we
+  // don't have an actual value to test against.
+  BOOST_CHECK_NO_THROW(bemppGrid->boundarySegmentCount());
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Test (boundarySegmentCount_agrees_with_Dune) was expected to fail because of a missing implementation in Dune.
However, it checked for result rather that for the unimplemented function to throw.
The current implementation checks that calling the Dune function does throw, and that calling the BEMPP function does not. It does not test the returned value for anything. 
