### PR TITLE
Disables Fortran in Dune build

### DIFF
--- a/cmake/Dune/lookup.cmake
+++ b/cmake/Dune/lookup.cmake
@@ -33,7 +33,7 @@ passon_variables(Dune
     FILENAME "${EXTERNAL_ROOT}/src/DuneVariables.cmake"
     PATTERNS
         "CMAKE_[^_]*_R?PATH" "CMAKE_C_.*" "CMAKE_CXX_.*"
-        "BLAS_.*" "LAPACK_.*" "CMAKE_Fortran_.*"
+        "BLAS_.*" "LAPACK_.*" "CMAKE_Fortran_.*" "ENABLE_Fortran"
     ALSOADD
         "\nset(CMAKE_INSTALL_PREFIX \"${EXTERNAL_ROOT}\" CACHE STRING \"\")\n"
         "set(CMAKE_LIBRARY_PATH ${library_dirs} \"${EXTERNAL_ROOT}/lib\"\n"
@@ -87,6 +87,7 @@ create_patch_script(Dune-Common dune_common_patch_script
     CMDLINE "-p0"
     WORKING_DIRECTORY "${EXTERNAL_ROOT}/src"
     "${patchdir}/dune_common_cmake.patch"
+    "${patchdir}/dune_disable_fortran.patch"
 )
 
 create_patch_script(Dune-Geometry dune_geometry_patch_script

--- a/cmake/patches/dune/dune_disable_fortran.patch
+++ b/cmake/patches/dune/dune_disable_fortran.patch
@@ -1,0 +1,13 @@
+--- dune-common/cmake/modules/DuneMacros.cmake
++++ dune-common/cmake/modules/DuneMacros.cmake.new
+@@ -551,7 +551,9 @@ macro(dune_project)
+ 
+   # optional Fortran support
+   include(LanguageSupport)
+-  workaround_9220(Fortran Fortran_Works)
++  if(ENABLE_Fortran)
++    workaround_9220(Fortran Fortran_Works)
++  endif()
+   if(Fortran_Works)
+     enable_language(Fortran OPTIONAL)
+   endif(Fortran_Works)


### PR DESCRIPTION
It is still possible to compile Dune with Fortran by passin
"-DENABLE_Fortran=TRUE" to cmake.

Closes #148.
