### PR TITLE
Travis-CI configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,7 @@ python:
   - 3.4
 env:
   - CXX="clang++"
-  # - CXX="g++"
-# matrix:
-#   include:
-#     - python: 3.4
-#       env:
-#         - CXX="clang++"
-#         - CXX="g++"
+  - CXX="g++"
 
 before_install:
   - sudo add-apt-repository -y ppa:kalakris/cmake
@@ -38,7 +32,7 @@ install:
 
   - if [ "$CXX" == "clang++" ]; then CXX=clang++-3.3; fi
 
-  - sudo apt-get install -qq cmake libboost-dev
+  - sudo apt-get install -qq cmake # libboost-dev
   - $CXX --version
 
   # You may want to periodically update this, although the conda update
@@ -62,6 +56,7 @@ install:
 
   - pip install "mako"
   - conda list
+
   - python setup.py install
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,42 @@
 language: python
 python:
   - 3.4
-# matrix:
-#   include:
-#     - python: 3.4
-#       env:
-#         - TEST_MATPLOTLIB="true"
+matrix:
+  include:
+    - python: 3.4
+      env:
+        - CXX="clang++"
+        # - CXX="g++"
+
 before_install:
   - sudo add-apt-repository -y ppa:kalakris/cmake
-  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  - if [ "$CXX" == "g++" ]; then     sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; fi
+  - if [ "$CXX" == "clang++" ]; then sudo add-apt-repository -y ppa:h-rayflood/llvm; fi
   - sudo apt-get update -qq
 
 install:
-  - sudo apt-get install -qq cmake gcc-4.8 g++-4.8
-  - alias gcc='gcc-4.8'
-  - alias g++='g++-4.8';
-  - export CC='gcc-4.8'; export CXX='g++-4.8';
-  - gcc --version
-  - g++ --version
+  # install g++ 4.8, if tests are run with g++
+  - if [ "$CXX" == "g++" ]; then sudo apt-get install -qq g++-4.8; fi
+  - if [ "$CXX" == "g++" ]; then sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50; fi
+
+  # install clang-3.3
+  - if [ "$CXX" == "clang++" ]; then sudo apt-get install --allow-unauthenticated -qq clang-3.3; fi
+  - if [ "$CXX" == "clang++" ]; then cwd=$(pwd); fi
+
+  # Install libc++ if tests are run with clang++
+  - if [ "$CXX" == "clang++" ]; then svn co --quiet http://llvm.org/svn/llvm-project/libcxx/trunk@181765 libcxx; fi
+
+  - if [ "$CXX" == "clang++" ]; then cd libcxx/lib && bash buildit; fi
+  - if [ "$CXX" == "clang++" ]; then sudo cp ./libc++.so.1.0 /usr/lib/; fi
+  - if [ "$CXX" == "clang++" ]; then sudo mkdir /usr/include/c++/v1; fi
+  - if [ "$CXX" == "clang++" ]; then cd .. && sudo cp -r include/* /usr/include/c++/v1/; fi
+  - if [ "$CXX" == "clang++" ]; then cd /usr/lib && sudo ln -sf libc++.so.1.0 libc++.so; fi
+  - if [ "$CXX" == "clang++" ]; then sudo ln -sf libc++.so.1.0 libc++.so.1 && cd $cwd; fi
+
+  - if [ "$CXX" == "clang++" ]; then CXX=clang++-3.3; fi
+
+  - sudo apt-get install -qq cmake
+  - $CXX --version
 
   # You may want to periodically update this, although the conda update
   # conda line below will keep everything up-to-date.  We do this

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,13 @@ python:
 #         - TEST_MATPLOTLIB="true"
 before_install:
   - sudo add-apt-repository -y ppa:kalakris/cmake
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
   - sudo apt-get update -qq
 
 install:
-  - sudo apt-get install -qq cmake
+  - sudo apt-get install -qq cmake gcc-4.8
+  - export CXX="g++-4.8"
+  - g++ --version
 
   # You may want to periodically update this, although the conda update
   # conda line below will keep everything up-to-date.  We do this

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+language: python
+python:
+  - 3.4
+# matrix:
+#   include:
+#     - python: 3.4
+#       env:
+#         - TEST_MATPLOTLIB="true"
+before_install:
+  - sudo add-apt-repository -y ppa:kalakris/cmake
+  - sudo apt-get update -qq
+
+install:
+  - sudo apt-get install -qq cmake
+
+  # You may want to periodically update this, although the conda update
+  # conda line below will keep everything up-to-date.  We do this
+  # conditionally because it saves us some downloading if the version is
+  # the same.
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      wget http://repo.continuum.io/miniconda/Miniconda-3.4.2-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget http://repo.continuum.io/miniconda/Miniconda3-3.4.2-Linux-x86_64.sh -O miniconda.sh;
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda info -a
+
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy cython sphinx pytest
+  - source activate test-environment
+
+  - pip install "mako"
+  - conda list
+
+  - mkdir build
+  - cd build
+  - cmake ..
+  - make
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,10 +62,7 @@ install:
 
   - pip install "mako"
   - conda list
+  - python setup.py install
 
-  - mkdir build
-  - cd build
-  - cmake ..
-  - make
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
 
   - if [ "$CXX" == "clang++" ]; then CXX=clang++-3.3; fi
 
-  - sudo apt-get install -qq cmake
+  - sudo apt-get install -qq cmake libboost-dev
   - $CXX --version
 
   # You may want to periodically update this, although the conda update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
 language: python
 python:
   - 3.4
-matrix:
-  include:
-    - python: 3.4
-      env:
-        - CXX="clang++"
-        # - CXX="g++"
+env:
+  - CXX="clang++"
+  # - CXX="g++"
+# matrix:
+#   include:
+#     - python: 3.4
+#       env:
+#         - CXX="clang++"
+#         - CXX="g++"
 
 before_install:
   - sudo add-apt-repository -y ppa:kalakris/cmake

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,11 @@ before_install:
   - sudo apt-get update -qq
 
 install:
-  - sudo apt-get install -qq cmake gcc-4.8
-  - export CXX="g++-4.8"
+  - sudo apt-get install -qq cmake gcc-4.8 g++-4.8
+  - alias gcc='gcc-4.8'
+  - alias g++='g++-4.8';
+  - export CC='gcc-4.8'; export CXX='g++-4.8';
+  - gcc --version
   - g++ --version
 
   # You may want to periodically update this, although the conda update

--- a/cmake/TBB/lookup.cmake
+++ b/cmake/TBB/lookup.cmake
@@ -8,9 +8,9 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   set(
     TBB_URL
-    http://www.threadingbuildingblocks.org/sites/default/files/software_releases/linux/tbb42_20140601oss_lin.tgz
+    https://www.threadingbuildingblocks.org/sites/default/files/software_releases/linux/tbb43_20141204oss_lin.tgz
   )
-  set(TBB_URL_MD5 8a13558019c9acfbab269e2b34f7fd27)
+  set(TBB_URL_MD5 d5d31f74c554097816aa02e2b9acfe51)
 else()
   message(FATAL_ERROR "Automatic install of TBB in windows not implemented")
 endif()

--- a/cmake/lookups/Trilinos-lookup.cmake
+++ b/cmake/lookups/Trilinos-lookup.cmake
@@ -131,8 +131,8 @@ ExternalProject_Add(
     PATCH_COMMAND ${patch_script}
     # Wrap download, configure and build steps in a script to log output
     LOG_DOWNLOAD ON
-    LOG_CONFIGURE ON
-    LOG_BUILD ON
+    LOG_CONFIGURE OFF
+    LOG_BUILD OFF
 )
 
 add_recursive_cmake_step(Trilinos DEPENDEES install)


### PR DESCRIPTION
https://travis-ci.org/thisch/bempp

travis ci currently fails due to compilation errors in the bempp source tree (see the logs). Is it possible that these errors are due to a too old gcc version (4.7.x) ?

The logging stuff in the trilinos cmake files is needed to avoid an abort of the travis build job