### PR TITLE
don't include complex.h in c++ code

### DIFF
--- a/python/bempp/utils/py_utils.mako.hpp
+++ b/python/bempp/utils/py_utils.mako.hpp
@@ -10,7 +10,7 @@
 #include <Teuchos_ParameterList.hpp>
 #include <algorithm>
 #include <sstream>
-#include <complex.h>
+#include <complex>
 
 namespace Bempp {
     inline static void catch_exception() {


### PR DESCRIPTION
use <complex> or <complex.hpp> instead

Otherwise I get compiler errors due to the preprocessor defines in complex.h which get expanded in some boost template arguments.

@tbetcke 