### PR TITLE
higher order fembem

### DIFF
--- a/python/bempp/fenics_interface/coupling.py
+++ b/python/bempp/fenics_interface/coupling.py
@@ -12,6 +12,50 @@ def boundary_grid_from_fenics_mesh(fenics_mesh):
     bempp_boundary_grid = grid_from_element_data(bm_coords.transpose(),bm_cells.transpose())
     return bempp_boundary_grid
 
+def generic_pn_trace(fenics_space):
+
+    import dolfin
+    from .coupling import fenics_space_info
+    from bempp import function_space, grid_from_element_data, GridFunction
+    import numpy as np
+
+    family,degree = fenics_space_info(fenics_space)
+    if not (family=='Lagrange'):
+        raise ValueError("fenics_space different from Lagrange space not yet tested!")
+
+    mesh = fenics_space.mesh()
+
+    bm = dolfin.BoundaryMesh(mesh,"exterior",False)
+    bm_nodes  = bm.entity_map(0).array().astype(np.int64)
+    bm_coords = bm.coordinates()
+    bm_cells  = bm.cells()
+    bempp_boundary_grid = grid_from_element_data(bm_coords.transpose(),bm_cells.transpose())
+
+    # Create compatible trace function space
+    space = function_space(bempp_boundary_grid,"P",degree)
+
+    # Now compute the mapping from BEM++ dofs to FEniCS dofs
+    from scipy.sparse import coo_matrix
+    def FenicsData(x, n, domain_index, result):
+        value = np.empty(1)
+        u_FEM.eval(value, x)
+        result[0] = value
+
+    u_FEM = dolfin.Function(fenics_space)
+    N = u_FEM.vector().size()
+    u_FEM.vector()[:] = np.arange(N)
+    u_BEM = GridFunction(space, dual_space=space,fun=FenicsData)
+    FEM2BEM = np.rint(u_BEM.coefficients).astype(np.int64)
+    if max(abs(FEM2BEM-u_BEM.coefficients)) > 0.01:
+        raise ValueError("interpolation from FEM to BEM space too inaccurate.")
+    NB = len(FEM2BEM)
+    trace_matrix = coo_matrix((
+        np.ones(NB),(np.arange(NB),FEM2BEM)),
+        shape=(NB,N),dtype='float64').tocsc()
+
+    # Now return everything
+    return (space,trace_matrix)
+
 def fenics_to_bempp_trace_data(fenics_space):
     """
     Returns tuple (space,trace_matrix)
@@ -24,7 +68,7 @@ def fenics_to_bempp_trace_data(fenics_space):
             import p1_coupling
             return p1_coupling.p1_trace(fenics_space)
         else:
-            raise NotImplementedError()
+            return generic_pn_trace(fenics_space)
     else:
         raise NotImplementedError()
 

--- a/python/bempp/fenics_interface/p1_coupling.py
+++ b/python/bempp/fenics_interface/p1_coupling.py
@@ -1,5 +1,5 @@
 
-def p1_dof_to_vertex_matrix(space):
+def p1_dof_to_vertex_matrix(space): # NOTE: function not used!?
 
     import numpy as np
 


### PR DESCRIPTION
implemented generic fem bem coupling method, based on the fencis eval() function. 

a fencis function is created and each dof value is set on the index of the corresponding dof. using the function's eval() method allows to evaluate its value on arbitrary points. Interpolation into the bempp space is done by creating a GridFunction. Extracting the coefficients of the resulting GridFunction then allows to setup the proper trace_matrix. 

Theoretically this should work for arbitrary element orders and types as long as identical element definitions are used and the interpolation into the bempp space is exact. 

there is still an open problem on how to get the necessary quadrature order to make the interpolation exact!? for 2nd/3rd order CG element `global_parameters.quadrature.far.single_order > 4/7` was required.

the code gives the same results as the p1_coupling for lowest order elements. additionally the `helm.py` example from matthew gives resonable results. 

greetings 
Florian Bruckner