### PR TITLE
make fenics_operator use PETSc by default (which makes it work with f…

### DIFF
--- a/python/bempp/fenics_interface/fenics_operator.py
+++ b/python/bempp/fenics_interface/fenics_operator.py
@@ -1,21 +1,28 @@
-import dolfin as _dolfin
-import numpy as _np
+from dolfin import as_backend_type, assemble, parameters
+from scipy.sparse import csr_matrix
 
 class FenicsOperator(object):
 
     def __init__(self,fenics_weak_form):
-
         self._fenics_weak_form = fenics_weak_form
+        self._sparse_mat = None
 
     def weak_form(self):
+        if self._sparse_mat is not None:
+            return self._sparse_mat
 
-        # Currently have to assemble using uBLAS
-        # Therefore need to save current backend and restore
-        # after assembly.
-        
-        backend = _dolfin.parameters['linear_algebra_backend']
-        _dolfin.parameters['linear_algebra_backend'] = 'uBLAS'
-        sparse_mat = _dolfin.assemble(self._fenics_weak_form).sparray()
-        _dolfin.parameters['linear_algebra_backend'] = backend
+        backend = parameters['linear_algebra_backend']
+        if backend not in ['PETSc', 'uBLAS']:
+            parameters['linear_algebra_backend'] = 'PETSc'
 
-        return sparse_mat
+        if parameters['linear_algebra_backend'] == 'PETSc':
+            A=as_backend_type(assemble(self._fenics_weak_form)).mat()
+            (indptr, indices, data) = A.getValuesCSR()
+            self._sparse_mat = csr_matrix((data, indices, indptr), shape=A.size)
+        elif parameters['linear_algebra_backend'] == 'uBLAS':
+            self._sparse_mat = assemble(self._fenics_weak_form).sparray()
+        else:
+            raise ValueError("This should not happen! Backend type is \'%s\' Default backend should have been set to 'PETSc'." % parameters['linear_algebra_backend'])
+
+        parameters['linear_algebra_backend'] = backend
+        return self._sparse_mat


### PR DESCRIPTION
make fenics_operator use PETSc by default (which makes it work with fenics 1.6.0)

use original uBLAS code if backend is uBLAS
cache weak form if assembled once