### PR TITLE
Python 3 fixes

### DIFF
--- a/cython/bempp/core/operators/boundary/laplace.pyx
+++ b/cython/bempp/core/operators/boundary/laplace.pyx
@@ -56,7 +56,7 @@ def single_layer_ext(
     cdef RealElementaryIntegralOperator op = RealElementaryIntegralOperator()
     op.impl_.assign(laplace_single_layer(
         deref(parameters.impl_),domain.impl_, range.impl_, dual_to_range.impl_,
-        _convert_to_bytes(label), symmetry_mode(symmetry)))
+        _convert_to_bytes(label), symmetry_mode(_convert_to_bytes(symmetry))))
     return op
 
 def double_layer_ext(
@@ -69,7 +69,7 @@ def double_layer_ext(
     cdef RealElementaryIntegralOperator op = RealElementaryIntegralOperator()
     op.impl_.assign(laplace_double_layer(
         deref(parameters.impl_),domain.impl_, range.impl_, dual_to_range.impl_,
-        _convert_to_bytes(label), symmetry_mode(symmetry)))
+        _convert_to_bytes(label), symmetry_mode(_convert_to_bytes(symmetry))))
     return op
         
 def adjoint_double_layer_ext(
@@ -82,7 +82,7 @@ def adjoint_double_layer_ext(
     cdef RealElementaryIntegralOperator op = RealElementaryIntegralOperator()
     op.impl_.assign(laplace_adjoint_double_layer(
         deref(parameters.impl_),domain.impl_, range.impl_, dual_to_range.impl_,
-        _convert_to_bytes(label), symmetry_mode(symmetry)))
+        _convert_to_bytes(label), symmetry_mode(_convert_to_bytes(symmetry))))
     return op
     
 def hypersingular_ext(
@@ -95,6 +95,5 @@ def hypersingular_ext(
     cdef RealElementaryIntegralOperator op = RealElementaryIntegralOperator()
     op.impl_.assign(laplace_hypersingular(
         deref(parameters.impl_),domain.impl_, range.impl_, dual_to_range.impl_,
-        _convert_to_bytes(label), symmetry_mode(symmetry)))
+        _convert_to_bytes(label), symmetry_mode(_convert_to_bytes(symmetry))))
     return op
-

--- a/cython/bempp/core/operators/boundary/maxwell.pyx
+++ b/cython/bempp/core/operators/boundary/maxwell.pyx
@@ -51,7 +51,7 @@ def electric_field_ext(
     op.impl_.assign(maxwell_single_layer(
         deref(parameters.impl_),domain.impl_, range.impl_, dual_to_range.impl_,
         complex_double(np.real(wave_number),np.imag(wave_number)),
-        _convert_to_bytes(label), symmetry_mode(symmetry)))
+        _convert_to_bytes(label), symmetry_mode(_convert_to_bytes(symmetry))))
     return op
 
 def magnetic_field_ext(
@@ -66,6 +66,5 @@ def magnetic_field_ext(
     op.impl_.assign(maxwell_double_layer(
         deref(parameters.impl_),domain.impl_, range.impl_, dual_to_range.impl_,
         complex_double(np.real(wave_number),np.imag(wave_number)),
-        _convert_to_bytes(label), symmetry_mode(symmetry)))
+        _convert_to_bytes(label), symmetry_mode(_convert_to_bytes(symmetry))))
     return op
-

--- a/cython/bempp/core/operators/boundary/modified_helmholtz.pyx
+++ b/cython/bempp/core/operators/boundary/modified_helmholtz.pyx
@@ -65,7 +65,7 @@ def single_layer_ext(
     op.impl_.assign(modified_helmholtz_single_layer(
         deref(parameters.impl_),domain.impl_, range.impl_, dual_to_range.impl_,
         complex_double(np.real(wave_number),np.imag(wave_number)),
-        _convert_to_bytes(label), symmetry_mode(symmetry)))
+        _convert_to_bytes(label), symmetry_mode(_convert_to_bytes(symmetry))))
     return op
 
 def double_layer_ext(
@@ -80,7 +80,7 @@ def double_layer_ext(
     op.impl_.assign(modified_helmholtz_double_layer(
         deref(parameters.impl_),domain.impl_, range.impl_, dual_to_range.impl_,
         complex_double(np.real(wave_number),np.imag(wave_number)),
-        _convert_to_bytes(label), symmetry_mode(symmetry)))
+        _convert_to_bytes(label), symmetry_mode(_convert_to_bytes(symmetry))))
     return op
 
 def adjoint_double_layer_ext(
@@ -95,7 +95,7 @@ def adjoint_double_layer_ext(
     op.impl_.assign(modified_helmholtz_adjoint_double_layer(
         deref(parameters.impl_),domain.impl_, range.impl_, dual_to_range.impl_,
         complex_double(np.real(wave_number),np.imag(wave_number)),
-        _convert_to_bytes(label), symmetry_mode(symmetry)))
+        _convert_to_bytes(label), symmetry_mode(_convert_to_bytes(symmetry))))
     return op
 
 def hypersingular_ext(
@@ -110,6 +110,5 @@ def hypersingular_ext(
     op.impl_.assign(modified_helmholtz_hypersingular(
         deref(parameters.impl_),domain.impl_, range.impl_, dual_to_range.impl_,
         complex_double(np.real(wave_number),np.imag(wave_number)),
-        _convert_to_bytes(label), symmetry_mode(symmetry)))
+        _convert_to_bytes(label), symmetry_mode(_convert_to_bytes(symmetry))))
     return op
-

--- a/cython/bempp/core/operators/boundary/sparse.pyx
+++ b/cython/bempp/core/operators/boundary/sparse.pyx
@@ -69,7 +69,7 @@ def identity_ext(
     cdef ElementaryLocalOperator op = ElementaryLocalOperator()
     op.impl_.assign(identity_operator(
         deref(parameters.impl_),domain.impl_, range.impl_, dual_to_range.impl_,
-        _convert_to_bytes(label), symmetry_mode(symmetry)))
+        _convert_to_bytes(label), symmetry_mode(_convert_to_bytes(symmetry))))
     return op
 
 def maxwell_identity_ext(
@@ -82,7 +82,7 @@ def maxwell_identity_ext(
     cdef ElementaryLocalOperator op = ElementaryLocalOperator()
     op.impl_.assign(maxwell_identity_operator(
         deref(parameters.impl_),domain.impl_, range.impl_, dual_to_range.impl_,
-        _convert_to_bytes(label), symmetry_mode(symmetry)))
+        _convert_to_bytes(label), symmetry_mode(_convert_to_bytes(symmetry))))
     return op
 
 def laplace_beltrami_ext(
@@ -95,7 +95,7 @@ def laplace_beltrami_ext(
     cdef ElementaryLocalOperator op = ElementaryLocalOperator()
     op.impl_.assign(laplace_beltrami_operator(
         deref(parameters.impl_),domain.impl_, range.impl_, dual_to_range.impl_,
-        _convert_to_bytes(label), symmetry_mode(symmetry)))
+        _convert_to_bytes(label), symmetry_mode(_convert_to_bytes(symmetry))))
     return op
 
 def curl_value_ext(Space domain, Space range, Space dual_to_range,

--- a/python/bempp/api/assembly/grid_function.py
+++ b/python/bempp/api/assembly/grid_function.py
@@ -237,6 +237,10 @@ class GridFunction(object):
 
         return self * (1./alpha)
 
+    def __truediv__(self, alpha):
+
+        return self.__div__(alpha)
+
     def __neg__(self):
 
         return self.__mul__(-1.0)
@@ -288,6 +292,3 @@ class GridFunction(object):
     def dtype(self):
         """Return the dtype."""
         return self._coefficients.dtype
-
-
-


### PR DESCRIPTION
Some small issues that I stumbled upon using python3 with the latest development branch. 

symmetry needs to be converted to bytes as label

when doing a division in either python3 or with from __future__ import division it calls ```__truediv__``` and not ```__div__```
