### PR TITLE
GMSH related fixes

### DIFF
--- a/python/bempp/api/assembly/test/test_discrete_boundary_operator.py
+++ b/python/bempp/api/assembly/test/test_discrete_boundary_operator.py
@@ -1,8 +1,11 @@
 from unittest import TestCase
+import unittest
+import bempp.api
 
 
 class TestGeneralNonlocalDiscreteBoundaryOperator(TestCase):
     """Test cases for general discrete operators."""
+
 
     def setUp(self):
         import bempp
@@ -205,6 +208,9 @@ class TestSparseDiscreteBoundaryOperator(TestCase):
 
 
 class TestInverseSparseDiscreteBoundaryOperator(TestCase):
+
+    requiresgmsh = unittest.skipIf(bempp.api.GMSH_PATH is None, reason="Needs GMSH")
+
     def setUp(self):
         import bempp
 
@@ -212,6 +218,7 @@ class TestInverseSparseDiscreteBoundaryOperator(TestCase):
         self._space_const = bempp.api.function_space(grid, "DP", 0)
         self._space_lin = bempp.api.function_space(grid, "P", 1)
 
+    @requiresgmsh
     def test_square_inverse(self):
         import bempp
         import numpy as np
@@ -225,6 +232,7 @@ class TestInverseSparseDiscreteBoundaryOperator(TestCase):
 
         self.assertAlmostEqual(np.linalg.norm(expected - actual), 0)
 
+    @requiresgmsh
     def test_inverse_of_thin_sparse_matrix(self):
         import bempp
         import numpy as np
@@ -241,6 +249,7 @@ class TestInverseSparseDiscreteBoundaryOperator(TestCase):
 
         self.assertAlmostEqual(np.linalg.norm(expected - actual), 0)
 
+    @requiresgmsh
     def test_inverse_of_thick_sparse_matrix(self):
         import bempp
         import numpy as np

--- a/python/bempp/api/shapes/shapes.py
+++ b/python/bempp/api/shapes/shapes.py
@@ -64,6 +64,8 @@ def __generate_grid_from_geo_string(geo_string):
 
     def msh_from_string(geo_string):
         gmsh_command = bempp.api.GMSH_PATH
+        if gmsh_command is None:
+            raise RuntimeError("Gmsh is not found. Cannot generate mesh")
         f, geo_name, msh_name = get_gmsh_file()
         f.write(geo_string)
         f.close()

--- a/python/bempp/api/space/test/test_barycentric_spaces.py
+++ b/python/bempp/api/space/test/test_barycentric_spaces.py
@@ -1,9 +1,12 @@
 from unittest import TestCase
+import unittest
 import bempp.api
 
 
 class TestBarycentricLinearSpace(TestCase):
     """Test linear spaces on barycentric grids."""
+
+    requiresgmsh = unittest.skipIf(bempp.api.GMSH_PATH is None, reason="Needs GMSH")
 
     def setUp(self):
 
@@ -11,10 +14,12 @@ class TestBarycentricLinearSpace(TestCase):
         self._bary_space = bempp.api.function_space(self._grid, "B-P", 1)
         self._space = bempp.api.function_space(self._grid, "P", 1)
 
+    @requiresgmsh
     def test_global_dof_count_agrees_with_non_barycentric_space(self):
 
         self.assertEqual(self._bary_space.global_dof_count, self._space.global_dof_count)
 
+    @requiresgmsh
     def test_mass_matrix_of_barycentric_space_agrees_with_non_barycentric_space(self):
 
         from bempp.api.operators.boundary.sparse import identity
@@ -27,6 +32,7 @@ class TestBarycentricLinearSpace(TestCase):
         self.assertAlmostEqual(diff.max(), 0, 15)
         self.assertAlmostEqual(diff.min(), 0, 15)
 
+    @requiresgmsh
     def test_slp_operator_on_barycentric_space_agrees_with_slp_on_non_barycentric_space(self):
 
         import numpy as np
@@ -44,6 +50,7 @@ class TestBarycentricLinearSpace(TestCase):
 
         self.assertAlmostEqual(diff, 0, 4)
 
+    @requiresgmsh
     def test_mass_matrix_of_barycentric_discontinuous_space_agrees_with_non_barycentric_discontinuous_space(self):
 
         from bempp.api.operators.boundary.sparse import identity
@@ -60,6 +67,7 @@ class TestBarycentricLinearSpace(TestCase):
         self.assertAlmostEqual(diff.max(), 0, 15)
         self.assertAlmostEqual(diff.min(), 0, 15)
 
+    @requiresgmsh
     def test_slp_operator_on_barycentric_discontinuous_space_agrees_with_slp_on_non_barycentric_disc_space(self):
 
         import numpy as np
@@ -83,5 +91,3 @@ if __name__ == "__main__":
     from unittest import main
 
     main()
-
-


### PR DESCRIPTION
Make sure Gmsh is found before trying to call it or raise informative error and skip tests that require Gmsh if it is not found. Fixes python tests on Legion where Gmsh is not yet installed. 