### PR TITLE
Fixes for  3 small bugs

### DIFF
--- a/cython/bempp/core/space/space.pyx
+++ b/cython/bempp/core/space/space.pyx
@@ -39,7 +39,7 @@ cdef class Space:
             (3xN) matrix of global interpolation points for the space,
             where each column is the coordinate of an interpolation point.
 
-        global_dof_interpolation_points : np.ndarray
+        global_dof_normals : np.ndarray
             (3xN) matrix of normal directions associated with the interpolation points.
 
         Notes
@@ -299,5 +299,3 @@ def function_space(Grid grid, kind, order, domains=None, cbool closed=True):
         raise ValueError("Unknown kind")
 
     return s
-
-

--- a/cython/bempp/core/utils/parameter_list.pyx
+++ b/cython/bempp/core/utils/parameter_list.pyx
@@ -58,7 +58,7 @@ cdef class _AssemblyParameterList:
         def __get__(self):
 
             cdef char* s = b"options.assembly.enableSingularIntegralCaching"
-            return (deref(self.impl_).get_string(s))
+            return (deref(self.impl_).get_bool(s))
 
         def __set__(self,cbool value):
 
@@ -326,6 +326,3 @@ cdef class ParameterList:
         
 
         
-
-
-

--- a/python/bempp/api/file_interfaces/gmsh.py
+++ b/python/bempp/api/file_interfaces/gmsh.py
@@ -159,7 +159,7 @@ class GmshInterface(FileInterfaceImpl):
         f.write("1\n")
         f.write("0\n")
         f.write("4\n")
-        f.write("0\n"+str(len(data.values()[0]))+"\n"+str(len(data))+"\n"+"0\n")
+        f.write("0\n"+str(len(list(data.values())[0]))+"\n"+str(len(data))+"\n"+"0\n")
         for key in data:
             f.write(str(key))
             for val in data[key]:
@@ -179,7 +179,7 @@ class GmshInterface(FileInterfaceImpl):
         f.write("1\n")
         f.write("0\n")
         f.write("4\n")
-        f.write("0\n"+str(len(data.values()[0]))+"\n"+str(len(data))+"\n"+"0\n")
+        f.write("0\n"+str(len(list(data.values())[0]))+"\n"+str(len(data))+"\n"+"0\n")
         for key in data:
             f.write(str(key))
             for val in data[key]:
@@ -199,7 +199,7 @@ class GmshInterface(FileInterfaceImpl):
         f.write("1\n")
         f.write("0\n")
         f.write("4\n")
-        f.write("0\n"+str(len(data.values()[0][:,0]))+"\n"+str(len(data))+"\n"+"0\n")
+        f.write("0\n"+str(len(list(data.values())[0][:,0]))+"\n"+str(len(data))+"\n"+"0\n")
         for key in data:
             f.write(str(key)+" 3")
             for i in range(3):
@@ -210,24 +210,3 @@ class GmshInterface(FileInterfaceImpl):
 
     def add_element_node_data(self, data, label):
         self._element_node_data = {'label':label, 'data':data}
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
* A copy past typo in a doc string 
* make sure that data.values() is a list before trying to index it. 

In python3 this returns a view which cannot be indexed so make sure to convert it to a list before indexing. As far as I can see this is always a rather short dictionary, so the performance implications should be negligible 

* Use get_bool to get enableSingularIntegralCaching which is a cbool