### PR TITLE
add Continuous Integration using TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
     - ./miniconda.sh -b -p $HOME/miniconda
     - export PATH=$HOME/miniconda/bin:$PATH
     - conda update conda -q -y
-    - conda install numpy scipy -q -y
+    - conda install python=2.7 numpy scipy -q -y
     - python -c 'import numpy'
     - python -c 'import scipy'
 ## same about cython ?
@@ -42,7 +42,7 @@ before_script:
 script:
 
 # ###### step 1: build
-#    ## travis_wait avoids time out when downloading
+#    ## `travis_wait` avoids time out when downloading
 #    ## and building external dependencies
 
     - mkdir -p build && cd build
@@ -57,7 +57,7 @@ script:
     - sudo make install
 
 # ###### step 3: test
-#    ## travis_wait has troubles with ""
+#    ## `travis_wait` has troubles with ""
 #    ## but travis_wait should be useful for intensive tests
 
 # ## Disable this test, because  it does not necessary pass.

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
     - python -c 'import numpy'
     - python -c 'import scipy'
 ## same about cython ?
-    - conda install cython -y -q
+    - conda install cython=0.23.4 -y -q
 
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,10 @@ script:
 
     - mkdir -p build && cd build
     - cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/miniconda
-    - travis_wait make
+    - make TBB
+    - make Boost
+    - make Dune
+    - make
 
 # ###### step 2: install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,75 @@
+dist: trusty
+sudo: required
+
+language: python
+python:
+    - "2.7"
+
+virtualenv:
+    system_site_packages: true
+
+
+branches:
+    only:
+        - eg-travis
+    except:
+        - master
+
+
+before_install:
+    - sudo apt-get update -qq
+    - sudo apt-get install g++ -qq -y
+    - sudo apt-get install cmake git make -qq -y
+    - sudo apt-get install cython python-dev -qq -y
+#    - sudo apt-get install python-numpy python-scipy -qq -y
+## TravisCI uses virtualenv and APT does not work
+## instead fix with use this ugly hack using conda
+    - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh -q
+    - chmod +x miniconda.sh
+    - ./miniconda.sh -b -p $HOME/miniconda
+    - export PATH=$HOME/miniconda/bin:$PATH
+    - conda update conda -q -y
+    - conda install numpy scipy -q -y
+    - python -c 'import numpy'
+    - python -c 'import scipy'
+## same about cython ?
+    - conda install cython -y -q
+
+
+before_script:
+    - git branch -avv
+
+script:
+
+# ###### step 1: build
+#    ## travis_wait avoids time out when downloading
+#    ## and building external dependencies
+
+    - mkdir -p build && cd build
+    - cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/miniconda
+    - travis_wait make
+
+# ###### step 2: install
+
+    - sudo make install
+
+# ###### step 3: test
+#    ## travis_wait has troubles with ""
+#    ## but travis_wait should be useful for intensive tests
+
+# ## Disable this test, because  it does not necessary pass.
+    - make test ARGS="-E python_tests"
+
+# ## Run test suite from python
+    - python -c "import bempp.api ; bempp.api.test()"
+
+
+#
+# This after_* is not doing what I expect
+#
+
+after_success:
+    - echo "Done."
+
+after_failure:
+    - echo "Failed."

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,10 @@ script:
 # ## Run test suite from python
     - python -c "import bempp.api ; bempp.api.test()"
 
+# ## Re-Run with Gmsh installed
+    - sudo apt-get install gmsh -q -y
+    - python -c "import bempp.api ; bempp.api.test()"
+
 
 #
 # This after_* is not doing what I expect


### PR DESCRIPTION
Add short `.travis.yml`, as example.

This file is the recipe to automatically build the bempp code, using the external service TravisCI.
The service allows to build several branch, with different options (python 2.7, 3.5, etc.), and then to run the test suite.

For example, the `eg-travis` branch of the fork is built at each push and the indicator is given by this bullet: [![Build Status](https://travis-ci.org/zimoun/bempp.svg?branch=eg-travis)](https://travis-ci.org/zimoun/bempp), which should be added in the `README`.
Moreover, options can be added, e.g., apply the build process at Pull-Request, etc.

This patch should add a quick view about the sanity of the project, and automatically report the issues of building (satisfied dependencies, etc.). Note that the external service TravisCI uses Ubuntu LTS (seems also possible to configure MacOS ?).

Hope this helps
