### PR TITLE
Jenkins trial and other things

### DIFF
--- a/cython/bempp/core/assembly/abstract_boundary_operator.pxd
+++ b/cython/bempp/core/assembly/abstract_boundary_operator.pxd
@@ -1,3 +1,4 @@
+cimport numpy
 from bempp.core.utils cimport unique_ptr
 from bempp.core.utils cimport shared_ptr
 from bempp.core.utils cimport complex_double

--- a/cython/bempp/core/assembly/assembler.pxd
+++ b/cython/bempp/core/assembly/assembler.pxd
@@ -1,3 +1,4 @@
+cimport numpy
 from bempp.core.utils cimport unique_ptr
 from bempp.core.utils cimport complex_double
 from bempp.core.utils cimport Matrix

--- a/cython/bempp/core/assembly/discrete_boundary_operator.pxd
+++ b/cython/bempp/core/assembly/discrete_boundary_operator.pxd
@@ -1,3 +1,4 @@
+cimport numpy
 from bempp.core.utils cimport Matrix
 from bempp.core.utils.enum_types cimport TranspositionMode
 from bempp.core.utils cimport shared_ptr

--- a/cython/bempp/core/assembly/discrete_boundary_operator.pyx
+++ b/cython/bempp/core/assembly/discrete_boundary_operator.pyx
@@ -1,13 +1,12 @@
+import numpy as np
+cimport numpy as np
+np.import_array()
+
 from bempp.core.utils cimport eigen_matrix_to_np_float64
 from bempp.core.utils cimport eigen_matrix_to_np_complex128
 from bempp.core.utils cimport enum_types as enums
 from libcpp cimport bool as cbool
 from cython.operator cimport dereference as deref
-
-import numpy as np
-cimport numpy as np
-
-
 
 cdef class RealDiscreteBoundaryOperator:
 

--- a/cython/bempp/core/assembly/discrete_operator_conversion.hpp
+++ b/cython/bempp/core/assembly/discrete_operator_conversion.hpp
@@ -46,11 +46,9 @@ PyObject *py_get_sparse_from_discrete_operator(
 
   // Now get the parameter objects
 
-  RealSparseMatrix::Index *indexOffset =
-      const_cast<RealSparseMatrix::Index *>(sparseOperator->outerIndexPtr());
-  RealSparseMatrix::Index *indices =
-      const_cast<RealSparseMatrix::Index *>(sparseOperator->innerIndexPtr());
-  double *values = const_cast<double *>(sparseOperator->valuePtr());
+  auto const indexOffset = sparseOperator->outerIndexPtr();
+  auto const indices = sparseOperator->innerIndexPtr();
+  auto const values = sparseOperator->valuePtr();
 
   npy_intp num_nonzeros = sparseOperator->nonZeros();
   npy_intp num_col_ptr = 1 + sparseOperator->cols();

--- a/cython/bempp/core/assembly/function_projector.pyx
+++ b/cython/bempp/core/assembly/function_projector.pyx
@@ -1,3 +1,7 @@
+cimport numpy
+import numpy
+numpy.import_array()
+
 from bempp.core.utils cimport Vector
 from bempp.core.utils cimport complex_double
 from bempp.core.utils cimport c_ParameterList

--- a/cython/bempp/core/common/global_parameters.pyx
+++ b/cython/bempp/core/common/global_parameters.pyx
@@ -1,3 +1,4 @@
+cimport numpy
 from bempp.core.utils cimport c_ParameterList, ParameterList
 from cython.operator cimport dereference as deref
 

--- a/cython/bempp/core/fiber/arrays.pxd
+++ b/cython/bempp/core/fiber/arrays.pxd
@@ -1,4 +1,4 @@
-
+cimport numpy
 
 cdef extern from "bempp/common/multidimensional_arrays.hpp" namespace "Fiber":
     cdef cppclass _4dArray "Fiber::_4dArray<double>":

--- a/cython/bempp/core/fiber/integrators.pyx
+++ b/cython/bempp/core/fiber/integrators.pyx
@@ -1,3 +1,4 @@
+cimport numpy
 from bempp.core.utils cimport Matrix
 from bempp.core.utils cimport eigen_matrix_to_np_float64
 from libcpp.vector cimport vector

--- a/cython/bempp/core/fiber/shapeset.pxd
+++ b/cython/bempp/core/fiber/shapeset.pxd
@@ -1,3 +1,4 @@
+cimport numpy
 from bempp.core.utils cimport Matrix
 from bempp.core.fiber.arrays cimport _3dArray
 from bempp.core.fiber.arrays cimport _4dArray

--- a/cython/bempp/core/grid/entity.pxd
+++ b/cython/bempp/core/grid/entity.pxd
@@ -1,3 +1,4 @@
+cimport numpy
 from bempp.core.utils cimport unique_ptr
 from bempp.core.grid.geometry cimport c_Geometry
 from bempp.core.grid.codim_template cimport codim_zero,codim_one,codim_two

--- a/cython/bempp/core/grid/entity_iterator.pxd
+++ b/cython/bempp/core/grid/entity_iterator.pxd
@@ -1,3 +1,4 @@
+cimport numpy
 from bempp.core.utils cimport unique_ptr, catch_exception
 from libcpp cimport bool as cbool
 from bempp.core.grid.codim_template cimport codim_zero,codim_one,codim_two

--- a/cython/bempp/core/grid/entity_pointer.pxd
+++ b/cython/bempp/core/grid/entity_pointer.pxd
@@ -1,3 +1,4 @@
+cimport numpy
 from bempp.core.utils cimport unique_ptr
 from bempp.core.grid.codim_template cimport codim_zero,codim_one,codim_two
 

--- a/cython/bempp/core/grid/geometry.pxd
+++ b/cython/bempp/core/grid/geometry.pxd
@@ -1,3 +1,4 @@
+cimport numpy
 from libcpp cimport bool as cbool
 from bempp.core.utils cimport Matrix, RowVector
 

--- a/cython/bempp/core/grid/grid.pxd
+++ b/cython/bempp/core/grid/grid.pxd
@@ -1,3 +1,4 @@
+cimport numpy
 from bempp.core.utils cimport shared_ptr,unique_ptr
 from bempp.core.utils cimport Vector
 from bempp.core.utils cimport Matrix

--- a/cython/bempp/core/grid/grid_factory.pyx
+++ b/cython/bempp/core/grid/grid_factory.pyx
@@ -1,3 +1,4 @@
+cimport numpy
 from bempp.core.utils cimport catch_exception
 from bempp.core.utils cimport shared_ptr
 from bempp.core.grid.grid cimport c_Grid

--- a/cython/bempp/core/grid/grid_view.pxd
+++ b/cython/bempp/core/grid/grid_view.pxd
@@ -1,3 +1,6 @@
+import numpy as np
+cimport numpy as np
+
 from bempp.core.utils cimport unique_ptr
 from bempp.core.grid.codim_template cimport codim_zero,codim_one,codim_two
 from bempp.core.grid.grid cimport Grid
@@ -11,9 +14,6 @@ from bempp.core.utils cimport Matrix, Vector
 from bempp.core.grid.entity_iterator cimport EntityIterator0
 from bempp.core.grid.entity_iterator cimport EntityIterator1
 from bempp.core.grid.entity_iterator cimport EntityIterator2
-
-import numpy as np
-cimport numpy as np
 
 cdef extern from "bempp/grid/grid_view.hpp" namespace "Bempp":
     cdef cppclass c_GridView "Bempp::GridView":

--- a/cython/bempp/core/grid/id_set.pxd
+++ b/cython/bempp/core/grid/id_set.pxd
@@ -1,3 +1,4 @@
+cimport numpy
 from bempp.core.grid.codim_template cimport codim_zero,codim_one,codim_two
 from bempp.core.grid.entity cimport c_Entity
 from bempp.core.grid.entity cimport Entity0, Entity1, Entity2

--- a/cython/bempp/core/grid/index_set.pxd
+++ b/cython/bempp/core/grid/index_set.pxd
@@ -1,3 +1,4 @@
+cimport numpy
 from bempp.core.grid.codim_template cimport codim_zero,codim_one,codim_two
 from bempp.core.grid.entity cimport c_Entity
 from bempp.core.grid.entity cimport Entity0, Entity1, Entity2

--- a/cython/bempp/core/hmat/hmatrix_data.pxd
+++ b/cython/bempp/core/hmat/hmatrix_data.pxd
@@ -1,3 +1,4 @@
+cimport numpy
 from bempp.core.utils.enum_types cimport HMatBlockType
 from bempp.core.utils cimport shared_ptr
 from bempp.core.utils cimport complex_double

--- a/cython/bempp/core/operators/far_field/helmholtz.pyx
+++ b/cython/bempp/core/operators/far_field/helmholtz.pyx
@@ -1,5 +1,8 @@
 __all__=['single_layer','double_layer']
 
+cimport numpy as _np
+import numpy as _np
+
 from bempp.core.utils cimport shared_ptr
 from bempp.core.utils cimport catch_exception
 from bempp.core.utils cimport complex_double
@@ -10,9 +13,6 @@ from bempp.core.space cimport Space, c_Space
 from bempp.core.utils cimport np_to_eigen_matrix_float64, Matrix
 from bempp.core.utils cimport c_ParameterList, ParameterList
 from cython.operator cimport dereference as deref
-
-cimport numpy as _np
-import numpy as _np
 
 cdef extern from "bempp/operators/helmholtz_operators.hpp" namespace "Bempp":
     cdef shared_ptr[const c_DiscreteBoundaryOperator[complex_double]] helmholtz_single_layer_far_field_discrete_operator "Bempp::helmholtzSingleLayerFarFieldOperator<double>"(

--- a/cython/bempp/core/operators/far_field/maxwell.pyx
+++ b/cython/bempp/core/operators/far_field/maxwell.pyx
@@ -1,5 +1,8 @@
 __all__=['single_layer','double_layer']
 
+cimport numpy as _np
+import numpy as _np
+
 from bempp.core.utils cimport shared_ptr
 from bempp.core.utils cimport catch_exception
 from bempp.core.utils cimport complex_double
@@ -10,9 +13,6 @@ from bempp.core.space cimport Space, c_Space
 from bempp.core.utils cimport np_to_eigen_matrix_float64, Matrix
 from bempp.core.utils cimport c_ParameterList, ParameterList
 from cython.operator cimport dereference as deref
-
-cimport numpy as _np
-import numpy as _np
 
 cdef extern from "bempp/operators/maxwell_operators.hpp" namespace "Bempp":
     cdef shared_ptr[const c_DiscreteBoundaryOperator[complex_double]] electric_far_field "Bempp::electricFieldFarFieldOperator<double>"(

--- a/cython/bempp/core/operators/potential/laplace.pyx
+++ b/cython/bempp/core/operators/potential/laplace.pyx
@@ -1,5 +1,8 @@
 __all__=['single_layer','double_layer']
 
+cimport numpy as _np
+import numpy as _np
+
 from bempp.core.utils cimport shared_ptr
 from bempp.core.utils cimport catch_exception
 from bempp.core.assembly.discrete_boundary_operator cimport c_DiscreteBoundaryOperator
@@ -8,9 +11,6 @@ from bempp.core.space cimport Space, c_Space
 from bempp.core.utils cimport np_to_eigen_matrix_float64, Matrix
 from bempp.core.utils cimport c_ParameterList, ParameterList
 from cython.operator cimport dereference as deref
-
-cimport numpy as _np
-import numpy as _np
 
 cdef extern from "bempp/operators/laplace_operators.hpp" namespace "Bempp":
     cdef shared_ptr[const c_DiscreteBoundaryOperator[double]] laplace_single_layer_potential_operator "Bempp::laplaceSingleLayerPotentialOperator<double,double>"(

--- a/cython/bempp/core/operators/potential/maxwell.pyx
+++ b/cython/bempp/core/operators/potential/maxwell.pyx
@@ -1,5 +1,8 @@
 __all__=['single_layer','double_layer']
 
+cimport numpy as _np
+import numpy as _np
+
 from bempp.core.utils cimport shared_ptr
 from bempp.core.utils cimport catch_exception
 from bempp.core.utils cimport complex_double
@@ -10,9 +13,6 @@ from bempp.core.space cimport Space, c_Space
 from bempp.core.utils cimport np_to_eigen_matrix_float64, Matrix
 from bempp.core.utils cimport c_ParameterList, ParameterList
 from cython.operator cimport dereference as deref
-
-cimport numpy as _np
-import numpy as _np
 
 cdef extern from "bempp/operators/maxwell_operators.hpp" namespace "Bempp":
     cdef shared_ptr[const c_DiscreteBoundaryOperator[complex_double]] maxwell_electric_field_potential_operator "Bempp::electricFieldPotentialOperator<double>"(

--- a/cython/bempp/core/operators/potential/modified_helmholtz.pyx
+++ b/cython/bempp/core/operators/potential/modified_helmholtz.pyx
@@ -1,5 +1,8 @@
 __all__=['single_layer','double_layer']
 
+cimport numpy as _np
+import numpy as _np
+
 from bempp.core.utils cimport shared_ptr
 from bempp.core.utils cimport catch_exception
 from bempp.core.utils cimport complex_double
@@ -10,9 +13,6 @@ from bempp.core.space cimport Space, c_Space
 from bempp.core.utils cimport np_to_eigen_matrix_float64, Matrix
 from bempp.core.utils cimport c_ParameterList, ParameterList
 from cython.operator cimport dereference as deref
-
-cimport numpy as _np
-import numpy as _np
 
 cdef extern from "bempp/operators/modified_helmholtz_operators.hpp" namespace "Bempp":
     cdef shared_ptr[const c_DiscreteBoundaryOperator[complex_double]] modified_helmholtz_single_layer_potential_discrete_operator "Bempp::modifiedHelmholtzSingleLayerPotentialOperator<double, std::complex<double>>"(

--- a/cython/bempp/core/space/space.pxd
+++ b/cython/bempp/core/space/space.pxd
@@ -1,3 +1,4 @@
+cimport numpy
 from bempp.core.utils cimport Matrix, Vector
 from bempp.core.utils cimport eigen_matrix_to_np_float64
 from bempp.core.utils cimport catch_exception

--- a/cython/bempp/core/utils/parameter_list.pxd
+++ b/cython/bempp/core/utils/parameter_list.pxd
@@ -1,3 +1,4 @@
+cimport numpy
 from bempp.core.utils cimport shared_ptr
 from libcpp.string cimport string 
 from libcpp cimport bool as cbool

--- a/python/bempp/api/assembly/test/test_boundary_operator.py
+++ b/python/bempp/api/assembly/test/test_boundary_operator.py
@@ -1,10 +1,9 @@
 from unittest import TestCase
+import bempp.api
 
 
 class TestBoundaryOperator(TestCase):
     def setUp(self):
-        import bempp
-
         grid = bempp.api.shapes.regular_sphere(2)
         self.domain = bempp.api.function_space(grid, "DP", 0)
         self.range_ = bempp.api.function_space(grid, "DP", 1)
@@ -45,7 +44,6 @@ class TestBoundaryOperator(TestCase):
                               "Sum of operators should be of type _ScaledBoundaryOperator.")
 
     def test_product_of_two_operators_is_product_operator(self):
-        import bempp
         from bempp.api.assembly.boundary_operator import _ProductBoundaryOperator
 
         op = bempp.api.operators.boundary.laplace.single_layer(self.domain, self.domain, self.domain)
@@ -55,11 +53,9 @@ class TestBoundaryOperator(TestCase):
 
     def test_weak_form_of_local_operator_is_sparse_discrete_operator(self):
         from bempp.api.assembly.discrete_boundary_operator import SparseDiscreteBoundaryOperator
-
         self.assertIsInstance(self._local_operator.weak_form(), SparseDiscreteBoundaryOperator)
 
     def test_weak_form_of_dense_operator_is_dense_discrete_operator(self):
-        import bempp
         from bempp.api.assembly.discrete_boundary_operator import DenseDiscreteBoundaryOperator
 
         assembly_mode = bempp.api.global_parameters.assembly.boundary_operator_assembly_type

--- a/python/bempp/api/assembly/test/test_grid_function.py
+++ b/python/bempp/api/assembly/test/test_grid_function.py
@@ -18,7 +18,7 @@ class TestGridFunction(TestCase):
         coefficients = np.ones(n)
         grid_fun = bempp.api.GridFunction(self._space, coefficients=coefficients)
 
-        self.assertAlmostEquals(np.linalg.norm(coefficients - grid_fun.coefficients), 0)
+        self.assertAlmostEqual(np.linalg.norm(coefficients - grid_fun.coefficients), 0)
 
     def test_set_coefficients(self):
         import numpy as np
@@ -27,7 +27,7 @@ class TestGridFunction(TestCase):
         coefficients = np.ones(n)
         grid_fun = bempp.api.GridFunction(self._space, coefficients=coefficients)
         grid_fun.coefficients *= 2
-        self.assertAlmostEquals(np.linalg.norm(2 * coefficients - grid_fun.coefficients), 0)
+        self.assertAlmostEqual(np.linalg.norm(2 * coefficients - grid_fun.coefficients), 0)
 
     def test_initialize_from_real_function(self):
         import numpy as np
@@ -38,7 +38,7 @@ class TestGridFunction(TestCase):
         grid_fun = bempp.api.GridFunction(self._space, fun=fun)
         actual = grid_fun.coefficients
         expected = self._space.global_dof_interpolation_points[0, :]
-        self.assertAlmostEquals(np.linalg.norm(actual - expected), 0)
+        self.assertAlmostEqual(np.linalg.norm(actual - expected), 0)
         self.assertEqual(grid_fun.dtype, 'float64')
 
     def test_initialize_from_complex_function(self):
@@ -50,7 +50,7 @@ class TestGridFunction(TestCase):
         grid_fun = bempp.api.GridFunction(self._space, fun=fun)
         actual = grid_fun.coefficients
         expected = self._space.global_dof_interpolation_points[0, :]
-        self.assertAlmostEquals(np.linalg.norm(actual - 1j * expected), 0)
+        self.assertAlmostEqual(np.linalg.norm(actual - 1j * expected), 0)
         self.assertEqual(grid_fun.dtype, 'complex128')
 
     def test_initialize_from_projections(self):
@@ -63,7 +63,7 @@ class TestGridFunction(TestCase):
 
         grid_fun = bempp.api.GridFunction(self._space, projections=projections)
 
-        self.assertAlmostEquals(np.linalg.norm(coefficients - grid_fun.coefficients), 0)
+        self.assertAlmostEqual(np.linalg.norm(coefficients - grid_fun.coefficients), 0)
 
     def test_add_two_grid_functions(self):
         import numpy as np
@@ -80,7 +80,7 @@ class TestGridFunction(TestCase):
         expected = 2 * grid_fun.coefficients
         actual = grid_fun2.coefficients
 
-        self.assertAlmostEquals(np.linalg.norm(expected - actual), 0)
+        self.assertAlmostEqual(np.linalg.norm(expected - actual), 0)
 
     def test_scalar_multiply_grid_function(self):
         import numpy as np
@@ -97,7 +97,7 @@ class TestGridFunction(TestCase):
         expected = 2 * grid_fun.coefficients
         actual = grid_fun2.coefficients
 
-        self.assertAlmostEquals(np.linalg.norm(expected - actual), 0)
+        self.assertAlmostEqual(np.linalg.norm(expected - actual), 0)
 
     def test_scalar_divide_grid_function(self):
         import numpy as np
@@ -114,7 +114,7 @@ class TestGridFunction(TestCase):
         expected = grid_fun.coefficients/2
         actual = grid_fun2.coefficients
 
-        self.assertAlmostEquals(np.linalg.norm(expected - actual), 0)
+        self.assertAlmostEqual(np.linalg.norm(expected - actual), 0)
 
     def test_negate_grid_function(self):
         import numpy as np
@@ -131,7 +131,7 @@ class TestGridFunction(TestCase):
         expected = -grid_fun.coefficients
         actual = grid_fun2.coefficients
 
-        self.assertAlmostEquals(np.linalg.norm(expected - actual), 0)
+        self.assertAlmostEqual(np.linalg.norm(expected - actual), 0)
 
     def test_l2_norm(self):
 

--- a/tests/ProjectInclusionUnitTests.in.cmake
+++ b/tests/ProjectInclusionUnitTests.in.cmake
@@ -19,7 +19,7 @@ assert_file_included(bempp/fiber/types.hpp           ${BEMPP_INCLUDE_DIRS})
 assert_file_included(boost/array.hpp                 ${BEMPP_INCLUDE_DIRS})
 assert_file_included(dune/grid/onedgrid.hh           ${BEMPP_INCLUDE_DIRS})
 assert_file_included(bempp/common/bempp_dune_config.hpp ${BEMPP_INCLUDE_DIRS})
-assert_file_included(tbb/atomic.h                    ${BEMPP_INCLUDE_DIRS})
+assert_file_included(atomic.h                    ${BEMPP_INCLUDE_DIRS})
 
 if(NOT DEFINED BEMPP_PYTHON_INCLUDE_DIRS)
     message(FATAL_ERROR "Expected BEMPP_PYTHON_INCLUDE_DIRS to be defined")


### PR DESCRIPTION
This should test the updated jenkins setup.
There are also some minor changes:

- missing `cimport numpy` that prevent compilation on legion with gcc
- missing `numpy.import_array()` in cython modules that make use of Numpy C API
- long to int const_cast that doesn't seem necessary and fails to compile on gcc/legion
- stuff...